### PR TITLE
Fix bottom sheet title spacing and add real route geometry

### DIFF
--- a/RailMapiOS/Sources/BottomSheet/BottomSheetView.swift
+++ b/RailMapiOS/Sources/BottomSheet/BottomSheetView.swift
@@ -67,6 +67,7 @@ struct BottomSheetView: View {
         NavigationStack(path: $router.path) {
             contentView
                 .navigationTitle("My Journeys")
+                .navigationBarTitleDisplayMode(.inline)
                 .searchable(
                     text: searchTextBinding,
                     isPresented: searchPresentedBinding,

--- a/RailMapiOS/Sources/BottomSheet/BottomSheetViewModel.swift
+++ b/RailMapiOS/Sources/BottomSheet/BottomSheetViewModel.swift
@@ -125,7 +125,7 @@ class BottomSheetViewModel: ObservableObject {
                     let firstCoord = CLLocationCoordinate2D(latitude: firstLat, longitude: firstLon)
                     let lastCoord = CLLocationCoordinate2D(latitude: lastLat, longitude: lastLon)
 
-                    return route.coordinates.first == firstCoord && route.coordinates.last == lastCoord
+                    return route.stopCoordinates.first == firstCoord && route.stopCoordinates.last == lastCoord
                 }
                 return false
             }) {

--- a/RailMapiOS/Sources/Map/MapSettings.swift
+++ b/RailMapiOS/Sources/Map/MapSettings.swift
@@ -98,16 +98,17 @@ class MapSettings: ObservableObject {
             return TrainRoute(coordinates: coordinates, company: journey.company)
         }
         updateCameraToShowAllRoutes()
+        resolveRouteGeometries()
     }
-    
+
     /// Sélectionne une route spécifique et centre la carte sur celle-ci
     func selectRoute(_ route: TrainRoute?) {
         if let route = route {
             selectedRoute = route
-            if !route.coordinates.isEmpty {
+            if !route.stopCoordinates.isEmpty {
                 withAnimation(.easeInOut(duration: 1.5)) {
                     cameraPosition = .region(MKCoordinateRegion(
-                        coordinates: route.coordinates,
+                        coordinates: route.stopCoordinates,
                         padding: 250
                     ))
                 }
@@ -123,10 +124,69 @@ class MapSettings: ObservableObject {
         updateCameraToShowAllRoutes()
     }
     
+    /// Résout les géométries réelles des routes via MKDirections
+    func resolveRouteGeometries() {
+        Task { @MainActor in
+            for index in trainRoutes.indices {
+                let route = trainRoutes[index]
+                guard route.stopCoordinates.count >= 2 else { continue }
+
+                var allPoints: [CLLocationCoordinate2D] = []
+
+                for i in 0..<(route.stopCoordinates.count - 1) {
+                    let origin = route.stopCoordinates[i]
+                    let destination = route.stopCoordinates[i + 1]
+
+                    if let segmentCoords = await Self.resolveSegment(from: origin, to: destination) {
+                        if allPoints.isEmpty {
+                            allPoints.append(contentsOf: segmentCoords)
+                        } else {
+                            allPoints.append(contentsOf: segmentCoords.dropFirst())
+                        }
+                    } else {
+                        if allPoints.isEmpty {
+                            allPoints.append(origin)
+                        }
+                        allPoints.append(destination)
+                    }
+                }
+
+                if allPoints.count > route.stopCoordinates.count {
+                    trainRoutes[index].routeCoordinates = allPoints
+                }
+            }
+        }
+    }
+
+    private static func resolveSegment(
+        from origin: CLLocationCoordinate2D,
+        to destination: CLLocationCoordinate2D
+    ) async -> [CLLocationCoordinate2D]? {
+        let request = MKDirections.Request()
+        request.source = MKMapItem(placemark: MKPlacemark(coordinate: origin))
+        request.destination = MKMapItem(placemark: MKPlacemark(coordinate: destination))
+        request.transportType = .automobile
+
+        let directions = MKDirections(request: request)
+        do {
+            let response = try await directions.calculate()
+            if let route = response.routes.first {
+                let polyline = route.polyline
+                let count = polyline.pointCount
+                var coords = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: count)
+                polyline.getCoordinates(&coords, range: NSRange(location: 0, length: count))
+                return coords
+            }
+        } catch {
+            LogManager.warning("MKDirections failed: \(error.localizedDescription)", category: "map")
+        }
+        return nil
+    }
+
     /// Met à jour la position de la caméra pour montrer toutes les routes
     func updateCameraToShowAllRoutes() {
         guard !trainRoutes.isEmpty else { return }
-        let allCoordinates = trainRoutes.flatMap { $0.coordinates }
+        let allCoordinates = trainRoutes.flatMap { $0.stopCoordinates }
         
         guard !allCoordinates.isEmpty else { return }
         
@@ -145,11 +205,15 @@ class MapSettings: ObservableObject {
 /// le tracé d'un trajet ferroviaire sur la carte.
 public struct TrainRoute: Identifiable, Equatable {
     public let id = UUID()
-    let coordinates: [CLLocationCoordinate2D]
+    /// Coordonnées des arrêts (pour les annotations sur la carte)
+    let stopCoordinates: [CLLocationCoordinate2D]
+    /// Coordonnées détaillées du tracé (résolu via MKDirections, sinon identique à stopCoordinates)
+    var routeCoordinates: [CLLocationCoordinate2D]
     let company: String?
 
     init(coordinates: [CLLocationCoordinate2D], company: String? = nil) {
-        self.coordinates = coordinates
+        self.stopCoordinates = coordinates
+        self.routeCoordinates = coordinates
         self.company = company
     }
 
@@ -168,8 +232,8 @@ public struct TrainRoute: Identifiable, Equatable {
 
     public static func == (lhs: TrainRoute, rhs: TrainRoute) -> Bool {
         return lhs.id == rhs.id &&
-        lhs.coordinates.first == rhs.coordinates.first &&
-        lhs.coordinates.last == rhs.coordinates.last
+        lhs.stopCoordinates.first == rhs.stopCoordinates.first &&
+        lhs.stopCoordinates.last == rhs.stopCoordinates.last
     }
 }
 

--- a/RailMapiOS/Sources/Map/MapView.swift
+++ b/RailMapiOS/Sources/Map/MapView.swift
@@ -37,14 +37,14 @@ struct MapView: View {
             let isSelected = mapSettings.selectedRoute?.id == route.id
             let hasSelection = mapSettings.selectedRoute != nil
 
-            MapPolyline(coordinates: route.coordinates)
+            MapPolyline(coordinates: route.routeCoordinates)
                 .stroke(
                     route.routeColor.opacity(hasSelection && !isSelected ? 0.3 : 1.0),
                     lineWidth: isSelected ? 5 : 3
                 )
                 .mapOverlayLevel(level: isSelected ? .aboveRoads : .aboveLabels)
 
-            if let firstCoord = route.coordinates.first {
+            if let firstCoord = route.stopCoordinates.first {
                 Annotation("", coordinate: firstCoord) {
                     Circle()
                         .fill(route.routeColor)
@@ -53,8 +53,8 @@ struct MapView: View {
                 }
             }
 
-            ForEach(1..<max(1, route.coordinates.count - 1), id: \.self) { index in
-                Annotation("", coordinate: route.coordinates[index]) {
+            ForEach(1..<max(1, route.stopCoordinates.count - 1), id: \.self) { index in
+                Annotation("", coordinate: route.stopCoordinates[index]) {
                     Circle()
                         .fill(route.routeColor.opacity(0.7))
                         .frame(width: 5, height: 5)
@@ -62,7 +62,7 @@ struct MapView: View {
                 }
             }
 
-            if let lastCoord = route.coordinates.last, route.coordinates.count > 1 {
+            if let lastCoord = route.stopCoordinates.last, route.stopCoordinates.count > 1 {
                 Annotation("", coordinate: lastCoord) {
                     Circle()
                         .fill(route.routeColor)


### PR DESCRIPTION
- Add .navigationBarTitleDisplayMode(.inline) to fix excessive title spacing
- Resolve route geometry via MKDirections for realistic map polylines
- Split TrainRoute into stopCoordinates (annotations) and routeCoordinates (polyline)
- Fall back to straight lines if MKDirections fails