### PR TITLE
Fix date selection tap not working with .searchable modifier

### DIFF
--- a/RailMapiOS/Sources/AddJourney/UI/DatePickerView.swift
+++ b/RailMapiOS/Sources/AddJourney/UI/DatePickerView.swift
@@ -25,32 +25,34 @@ struct DatePickerView: View {
                 .accessibilityIdentifier(AccessibilityID.DatePickerView.title)
 
             List(viewModel.dateRows) { row in
-                HStack(spacing: 12) {
-                    if let company = row.company {
-                        Image("icon_\(company.lowercased())_minimal")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxWidth: 44)
-                    }
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(row.journey.headsign)
-                            .font(.headline)
-                        Text("Detected train journey")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    Text(row.formattedDate)
-                        .font(.title3)
-                        .fontWeight(.medium)
-                        .monospacedDigit()
-                }
-                .accessibilityIdentifier(AccessibilityID.DatePickerView.dateRow(for: row.date))
-                .padding(.vertical, 6)
-                .contentShape(Rectangle())
-                .onTapGesture {
+                Button {
                     onNext(row)
+                } label: {
+                    HStack(spacing: 12) {
+                        if let company = row.company {
+                            Image("icon_\(company.lowercased())_minimal")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(maxWidth: 44)
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.journey.headsign)
+                                .font(.headline)
+                            Text("Detected train journey")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(row.formattedDate)
+                            .font(.title3)
+                            .fontWeight(.medium)
+                            .monospacedDigit()
+                    }
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(AccessibilityID.DatePickerView.dateRow(for: row.date))
             }
             .accessibilityIdentifier(AccessibilityID.DatePickerView.title)
             .listStyle(.plain)

--- a/RailMapiOS/Sources/AddJourney/UI/StationPickerView.swift
+++ b/RailMapiOS/Sources/AddJourney/UI/StationPickerView.swift
@@ -21,18 +21,20 @@ struct StationPickerView: View {
     var body: some View {
         List {
             ForEach(viewModel.pickedJourney.journey.stopTimes, id: \.stopPoint.id) { stopTime in
-                StationRow(
-                    stopTime: stopTime,
-                    cityName: viewModel.cityNames[stopTime.stopPoint.id],
-                    isSelected: isStationSelected(stopTime),
-                    isSelectable: isStationSelectable(stopTime)
-                )
-                .accessibilityIdentifier(AccessibilityID.StationPickerView.StationRow.stationRow(id: stopTime.stopPoint.id))
-                .onTapGesture {
+                Button {
                     if isStationSelectable(stopTime) {
                         toggleStationSelection(stopTime)
                     }
+                } label: {
+                    StationRow(
+                        stopTime: stopTime,
+                        cityName: viewModel.cityNames[stopTime.stopPoint.id],
+                        isSelected: isStationSelected(stopTime),
+                        isSelectable: isStationSelectable(stopTime)
+                    )
                 }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(AccessibilityID.StationPickerView.StationRow.stationRow(id: stopTime.stopPoint.id))
             }
         }
         .accessibilityIdentifier(AccessibilityID.StationPickerView.list)


### PR DESCRIPTION
Replace onTapGesture with Button in DatePickerView and StationPickerView List rows. When .searchable(isPresented:) is active, the first tap on a List item with onTapGesture is consumed by the keyboard dismiss gesture instead of triggering the action. Button handles this correctly as it is natively integrated with List's gesture system.